### PR TITLE
Add support for port reconfiguration

### DIFF
--- a/core/.clang-format
+++ b/core/.clang-format
@@ -1,34 +1,51 @@
 ---
-Language:        Cpp
 # BasedOnStyle:  Google
 AccessModifierOffset: -1
-AlignAfterOpenBracket: true
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
-AlignEscapedNewlinesLeft: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-
-# AllowShortFunctionsOnASingleLine: All
-# AllowShortIfStatementsOnASingleLine: true
-# AllowShortLoopsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-
 AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
@@ -36,18 +53,36 @@ Cpp11BracedListStyle: true
 DerivePointerAlignment: true
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: true
+IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
@@ -55,7 +90,11 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
@@ -65,7 +104,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Auto
+Standard:        Cpp11
 TabWidth:        2
 UseTab:          Never
 ...

--- a/core/drivers/pmd.cc
+++ b/core/drivers/pmd.cc
@@ -34,7 +34,6 @@
 
 #include "../utils/ether.h"
 #include "../utils/format.h"
-#include "../worker.h"
 
 /*!
  * The following are deprecated. Ignore us.
@@ -243,8 +242,6 @@ CommandResponse PMDPort::Init(const bess::pb::PMDPortArg &arg) {
 
   /* Use defaut rx/tx configuration as provided by PMD drivers,
    * with minor tweaks */
-  WorkerPauser wp;
-  rte_eth_dev_stop(ret_port_id);
   rte_eth_dev_info_get(ret_port_id, &dev_info);
 
   if (dev_info.driver_name) {
@@ -297,46 +294,74 @@ CommandResponse PMDPort::Init(const bess::pb::PMDPortArg &arg) {
     }
   }
 
-  if (vlan_offload) {
-    ret = rte_eth_dev_set_vlan_offload(ret_port_id, vlan_offload);
+  int offload_mask = 0;
+  offload_mask |= arg.vlan_offload_rx_strip() ? ETH_VLAN_STRIP_OFFLOAD : 0;
+  offload_mask |= arg.vlan_offload_rx_filter() ? ETH_VLAN_FILTER_OFFLOAD : 0;
+  offload_mask |= arg.vlan_offload_rx_qinq() ? ETH_VLAN_EXTEND_OFFLOAD : 0;
+  if (offload_mask) {
+    ret = rte_eth_dev_set_vlan_offload(ret_port_id, offload_mask);
     if (ret != 0) {
-      LOG(WARNING) << "rte_eth_dev_set_vlan_offload() failed: " << rte_strerror(-ret);
+      return CommandFailure(-ret, "rte_eth_dev_set_vlan_offload() failed");
     }
   }
 
-  if (mtu) {
-    ret = rte_eth_dev_set_mtu(ret_port_id, mtu);
-    if (ret != 0) {
-      LOG(WARNING) << "rte_eth_dev_set_mtu() failed: " << rte_strerror(-ret);
-    }
-  }
-
-  ret = rte_eth_dev_default_mac_addr_set(ret_port_id,
-                                         reinterpret_cast<ether_addr *>(&mac_addr));
+  ret = rte_eth_dev_start(ret_port_id);
   if (ret != 0) {
-    LOG(WARNING) << "rte_eth_dev_default_mac_addr_set failed: "
-                 << rte_strerror(-ret);
+    return CommandFailure(-ret, "rte_eth_dev_start() failed");
   }
-
-  if (admin_status_up) {
-     ret = rte_eth_dev_start(ret_port_id);
-     if (ret != 0) {
-       return CommandFailure(-ret, "rte_eth_dev_start() failed");
-     }
-  }
-
   dpdk_port_id_ = ret_port_id;
 
   numa_node = rte_eth_dev_socket_id(static_cast<int>(ret_port_id));
   node_placement_ =
       numa_node == -1 ? UNCONSTRAINED_SOCKET : (1ull << numa_node);
 
-  rte_eth_macaddr_get(dpdk_port_id_, reinterpret_cast<ether_addr *>(&mac_addr));
+  rte_eth_macaddr_get(dpdk_port_id_,
+                      reinterpret_cast<ether_addr *>(conf_.mac_addr.bytes));
 
   // Reset hardware stat counters, as they may still contain previous data
   CollectStats(true);
 
   return CommandSuccess();
+}
+
+int PMDPort::UpdateConf(const Conf &conf) {
+  rte_eth_dev_stop(dpdk_port_id_);
+
+  if (conf_.mtu != conf.mtu && conf.mtu != 0) {
+    int ret = rte_eth_dev_set_mtu(dpdk_port_id_, conf.mtu);
+    if (ret == 0) {
+      conf_.mtu = conf_.mtu;
+    } else {
+      LOG(WARNING) << "rte_eth_dev_set_mtu() failed: " << rte_strerror(-ret);
+      return ret;
+    }
+  }
+
+  if (conf_.mac_addr != conf.mac_addr && !conf.mac_addr.IsZero()) {
+    ether_addr tmp;
+    ether_addr_copy(reinterpret_cast<const ether_addr *>(&conf.mac_addr.bytes),
+                    &tmp);
+    int ret = rte_eth_dev_default_mac_addr_set(dpdk_port_id_, &tmp);
+    if (ret == 0) {
+      conf_.mac_addr = conf.mac_addr;
+    } else {
+      LOG(WARNING) << "rte_eth_dev_default_mac_addr_set() failed: "
+                   << rte_strerror(-ret);
+      return ret;
+    }
+  }
+
+  if (conf.admin_up) {
+    int ret = rte_eth_dev_start(dpdk_port_id_);
+    if (ret == 0) {
+      conf_.admin_up = true;
+    } else {
+      LOG(WARNING) << "rte_eth_dev_start() failed: " << rte_strerror(-ret);
+      return ret;
+    }
+  }
+
+  return 0;
 }
 
 void PMDPort::DeInit() {
@@ -410,20 +435,14 @@ void PMDPort::CollectStats(bool reset) {
 }
 
 int PMDPort::RecvPackets(queue_t qid, bess::Packet **pkts, int cnt) {
-  if (likely(admin_status_up)) {
-    return rte_eth_rx_burst(dpdk_port_id_, qid, (struct rte_mbuf **)pkts, cnt);
-  }
-  return 0;
+  return rte_eth_rx_burst(dpdk_port_id_, qid, (struct rte_mbuf **)pkts, cnt);
 }
 
 int PMDPort::SendPackets(queue_t qid, bess::Packet **pkts, int cnt) {
-  if (likely(admin_status_up)) {
-    int sent;
-    sent = rte_eth_tx_burst(dpdk_port_id_, qid, (struct rte_mbuf **)pkts, cnt);
-    queue_stats[PACKET_DIR_OUT][qid].dropped += (cnt - sent);
-    return sent;
-  }
-  return 0;
+  int sent = rte_eth_tx_burst(dpdk_port_id_, qid,
+                              reinterpret_cast<struct rte_mbuf **>(pkts), cnt);
+  queue_stats[PACKET_DIR_OUT][qid].dropped += (cnt - sent);
+  return sent;
 }
 
 Port::LinkStatus PMDPort::GetLinkStatus() {

--- a/core/drivers/pmd.h
+++ b/core/drivers/pmd.h
@@ -121,17 +121,19 @@ class PMDPort final : public Port {
    */
   int SendPackets(queue_t qid, bess::Packet **pkts, int cnt) override;
 
-  virtual uint64_t GetFlags() const override {
+  uint64_t GetFlags() const override {
     return DRIVER_FLAG_SELF_INC_STATS | DRIVER_FLAG_SELF_OUT_STATS;
   }
 
   LinkStatus GetLinkStatus() override;
 
+  int UpdateConf(const Conf &conf) override;
+
   /*!
    * Get any placement constraints that need to be met when receiving from this
    * port.
    */
-  virtual placement_constraint GetNodePlacementConstraint() const override {
+  placement_constraint GetNodePlacementConstraint() const override {
     return node_placement_;
   }
 

--- a/core/modules/port_inc.cc
+++ b/core/modules/port_inc.cc
@@ -102,13 +102,17 @@ std::string PortInc::GetDesc() const {
 struct task_result PortInc::RunTask(void *arg) {
   if (children_overload_ > 0) {
     return {
-      .block = true,
-      .packets = 0,
-      .bits = 0,
+        .block = true,
+        .packets = 0,
+        .bits = 0,
     };
   }
 
   Port *p = port_;
+
+  if (!p->conf().admin_up) {
+    return {.block = true, .packets = 0, .bits = 0};
+  }
 
   const queue_t qid = (queue_t)(uintptr_t)arg;
 

--- a/core/modules/queue_inc.cc
+++ b/core/modules/queue_inc.cc
@@ -87,6 +87,10 @@ std::string QueueInc::GetDesc() const {
 struct task_result QueueInc::RunTask(void *arg) {
   Port *p = port_;
 
+  if (!p->conf().admin_up) {
+    return {.block = true, .packets = 0, .bits = 0};
+  }
+
   const queue_t qid = (queue_t)(uintptr_t)arg;
 
   bess::PacketBatch batch;

--- a/core/modules/queue_out.cc
+++ b/core/modules/queue_out.cc
@@ -79,9 +79,11 @@ void QueueOut::ProcessBatch(bess::PacketBatch *batch) {
   const queue_t qid = qid_;
 
   uint64_t sent_bytes = 0;
-  int sent_pkts;
+  int sent_pkts = 0;
 
-  sent_pkts = p->SendPackets(qid, batch->pkts(), batch->cnt());
+  if (p->conf().admin_up) {
+    sent_pkts = p->SendPackets(qid, batch->pkts(), batch->cnt());
+  }
 
   if (!(p->GetFlags() & DRIVER_FLAG_SELF_OUT_STATS)) {
     const packet_dir_t dir = PACKET_DIR_OUT;

--- a/core/port.h
+++ b/core/port.h
@@ -203,12 +203,17 @@ class Port {
   // overide this section to create a new driver -----------------------------
   Port()
       : port_stats_(),
+        conf_(),
         name_(),
         port_builder_(),
         num_queues(),
         queue_size(),
         users(),
-        queue_stats() {}
+        queue_stats() {
+    conf_.mac_addr.Randomize();
+    conf_.mtu = kDefaultMtu;
+    conf_.admin_up = true;
+  }
 
   virtual ~Port() {}
 

--- a/core/utils/ether.cc
+++ b/core/utils/ether.cc
@@ -67,7 +67,7 @@ void Address::Randomize() {
   }
 
   bytes[0] &= 0xfe;  // not broadcast/multicast
-  bytes[1] |= 0x02;  // locally administered
+  bytes[0] |= 0x02;  // locally administered
 }
 
 }  // namespace utils

--- a/core/utils/ether.h
+++ b/core/utils/ether.h
@@ -42,10 +42,10 @@
 namespace bess {
 namespace utils {
 
-struct[[gnu::packed]] Ethernet {
-  struct[[gnu::packed]] Address {
+struct [[gnu::packed]] Ethernet {
+  struct [[gnu::packed]] Address {
     Address() = default;
-    Address(uint8_t *addr) { bess::utils::Copy(bytes, addr, kSize); }
+    Address(const uint8_t *addr) { bess::utils::Copy(bytes, addr, kSize); }
     Address(const std::string &str);
 
     static const size_t kSize = 6;
@@ -63,6 +63,11 @@ struct[[gnu::packed]] Ethernet {
     bool IsBroadcast() const {
       return bytes[0] == 0xff && bytes[1] == 0xff && bytes[2] == 0xff &&
              bytes[3] == 0xff && bytes[4] == 0xff && bytes[5] == 0xff;
+    }
+
+    bool IsZero() const {
+      return bytes[0] == 0x00 && bytes[1] == 0x00 && bytes[2] == 0x00 &&
+             bytes[3] == 0x00 && bytes[4] == 0x00 && bytes[5] == 0x00;
     }
 
     bool operator<(const Address &o) const {
@@ -109,7 +114,7 @@ struct[[gnu::packed]] Ethernet {
   be16_t ether_type;
 };
 
-struct[[gnu::packed]] Vlan {
+struct [[gnu::packed]] Vlan {
   be16_t tci;
   be16_t ether_type;
 };

--- a/protobuf/bess_msg.proto
+++ b/protobuf/bess_msg.proto
@@ -247,26 +247,36 @@ message CreatePortRequest {
   /// If not set (0), a driver-specific default value will be used.
   uint64 size_out_q = 6;
 
-  /// MAC address for the new port. Should be "xx:xx:xx:xx:xx:xx" format.
-  string mac_addr = 7;
+  /// Driver specific argument for port initialization. See port_msg.proto
+  google.protobuf.Any arg = 7;
+}
 
-  /// vlan offload mask, see ETH_VLAN_STRIP_OFFLOAD, ETH_VLAN_FILTER_OFFLOAD, and
-  /// ETH_VLAN_EXTEND_OFFLOAD for values that may be mixed with "OR".
-  /// Set to 0 for no offload.
-  uint64 vlan_offload = 8;
+/// All configuration parameters updatable at runtime
+message PortConf {
+  /// MAC address for the new port. Should be "xx:xx:xx:xx:xx:xx" format.
+  /// Set to '00:00:00:00:00:00' to use the default/current MAC address
+  string mac_addr = 1;
 
   /// Port MTU. Set to 0 to accept the default port MTU
-  uint64 mtu = 9;
+  uint32 mtu = 2;
 
-  enum AdminStatus {
-    UP = 0;
-    DOWN = 1;
-  }
-  /// Port administrative status. Default is UP
-  AdminStatus admin_status = 10;
+  /// Enable or disable the port.
+  /// Both admin and link (operational) states must be up to function
+  bool admin_up = 3;
+}
 
-  /// Driver specific argument for port initialization. See port_msg.proto
-  google.protobuf.Any arg = 11;
+message SetPortConfRequest {
+  string name = 1;  /// Name of port
+  PortConf conf = 2;
+}
+
+message GetPortConfRequest {
+  string name = 1;  /// Name of port
+}
+
+message GetPortConfResponse {
+  Error error = 1;
+  PortConf conf = 2;
 }
 
 message CreatePortResponse {

--- a/protobuf/ports/port_msg.proto
+++ b/protobuf/ports/port_msg.proto
@@ -42,6 +42,11 @@ message PMDPortArg {
     string pci = 3;
     string vdev = 4;
   }
+
+  // See http://dpdk.org/doc/dts/test_plans/dual_vlan_test_plan.html
+  bool vlan_offload_rx_strip = 5;
+  bool vlan_offload_rx_filter = 6;
+  bool vlan_offload_rx_qinq = 7;
 }
 
 message UnixSocketPortArg {

--- a/protobuf/service.proto
+++ b/protobuf/service.proto
@@ -203,6 +203,10 @@ service BESSControl {
   /// (e.g., PortInc, PortOut, QueueInc, QueueOut)
   rpc DestroyPort (DestroyPortRequest) returns (EmptyResponse) {}
 
+  /// Runtime-updatable configuration
+  rpc SetPortConf (SetPortConfRequest) returns (EmptyResponse) {}
+  rpc GetPortConf (GetPortConfRequest) returns (GetPortConfResponse) {}
+
   /// Collect port statistics
   ///
   /// At the moment, per-queue stats are not supported.

--- a/pybess/bess.py
+++ b/pybess/bess.py
@@ -361,10 +361,6 @@ class BESS(object):
         request.num_out_q = arg.pop('num_out_q', 0)
         request.size_inc_q = arg.pop('size_inc_q', 0)
         request.size_out_q = arg.pop('size_out_q', 0)
-        request.mac_addr = arg.pop('mac_addr', '')
-        request.mtu = arg.pop('mtu', 0);
-        request.vlan_offload = arg.pop('vlan_offload', 0);
-        request.admin_status = arg.pop('admin_status', 0);
 
         message_type = getattr(port_msg, driver + 'Arg', module_msg.EmptyArg)
         arg_msg = pb_conv.dict_to_protobuf(message_type, arg)


### PR DESCRIPTION
This PR is a RFC, to discuss further changes regarding https://github.com/NetSys/bess/pull/769. Sorry for this belated response.

The changes made here include the following concerns:
* `create_port` works for both create and update, which is not quite ideal from design perspective.
 * I added a separate API function for updating a port. Admin up/down, MTU, MAC address can be changed at runtime.
 * The above configuration parameters have been removed from `create_port`. I was a bit worried about the function being more complex.
* There is no API function to query the configuration for a port.
* Some configuration parameters are driver-specific. Arguably, the VLAN offloading option is specific to DPDK PMD driver, rather than generic.
* The Admin up/down status should be checked in `PortInc`/`PortOut`, not `PMDDriver`, since it is not supposed to be driver-specific.

Please check if this change aligns well with your intended use case. I am open to discussion for further changes. It is still incomplete (e.g., there is no interface to specify a VLAN tag id), so I would like to ask for more updates on top of this PR.